### PR TITLE
feature/hardening-optimization

### DIFF
--- a/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/.gitignore
+++ b/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/.gitignore
@@ -1,1 +1,2 @@
 bootstrap_win.txt
+thumbprint.txt

--- a/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/Hardening.ps1
+++ b/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/Hardening.ps1
@@ -1,0 +1,29 @@
+# Sample Hardening.ps1
+#
+# This script demonstrates a basic example of applying some CIS benchmarks for Windows Server 2022.
+# It is not exhaustive and should not be considered a complete solution for Windows hardening.
+
+# Disable SMBv1
+Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" SMB1 -Type DWORD -Value 0
+
+# Set Minimum Password Length to 14 characters
+Set-LocalUser -MinimumPasswordLength 14
+
+# Set Account Lockout Threshold to 5 invalid attempts
+net accounts /lockoutthreshold:5
+
+# Set Account Lockout Duration to 15 minutes
+net accounts /lockoutduration:15
+
+# Set Reset Account Lockout Counter After to 15 minutes
+net accounts /lockoutwindow:15
+
+# Configure Audit Policy to include Success and Failure for 'Account Logon Events' and 'Logon Events'
+auditpol /set /subcategory:"Account Logon" /success:enable /failure:enable
+auditpol /set /subcategory:"Logon" /success:enable /failure:enable
+
+# Enable Windows Firewall
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+
+# Block incoming traffic on unused ports (example: block incoming traffic on port 445)
+New-NetFirewallRule -DisplayName "Block Unused Port 445" -Direction Inbound -Protocol TCP -LocalPort 445 -Action Block

--- a/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
@@ -17,7 +17,7 @@ dism /online /Enable-Feature /FeatureName:NetFx4 /All
 $iisFeatures = @(
     "IIS-WebServerRole", "IIS-WebServer", "IIS-CommonHttpFeatures", "IIS-Security", "IIS-RequestFiltering", "IIS-StaticContent",
     "IIS-DefaultDocument", "IIS-DirectoryBrowsing", "IIS-HttpErrors", "IIS-ApplicationDevelopment", "IIS-WebSockets", "IIS-ApplicationInit",
-    "IIS-NetFxExtensibility45", "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ASP", "IIS-ASPNET45", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
+    "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
     "IIS-HttpLogging", "IIS-Performance", "IIS-HttpCompressionStatic", "IIS-WebServerManagementTools", "IIS-ManagementConsole", "IIS-ManagementService"
 )
 

--- a/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
@@ -32,8 +32,8 @@ Enable-WindowsFeatureIfNotEnabled -FeatureName "IIS-ASPNET45"
 Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install WebDeploy
-choco install webdeploy -y
+# # Install WebDeploy # Part of demo pre octopus
+# choco install webdeploy -y
 
 # Install .NET Hosting Bundle
 $dotNetHostingUrl = "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe"

--- a/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/DEV/DEV-WEB-X-AMI/ISS.ps1
@@ -1,48 +1,45 @@
+# Function to enable features with error checking
+function Enable-WindowsFeatureIfNotEnabled {
+    param (
+        [string]$FeatureName
+    )
 
-# Install IIS and its dependencies
-# To list all Windows Features: dism /online /Get-Features
-# Get-WindowsOptionalFeature -Online 
-# LIST All IIS FEATURES: 
-# Get-WindowsOptionalFeature -Online | where FeatureName -like 'IIS-*'
+    $feature = Get-WindowsOptionalFeature -Online -FeatureName $FeatureName
+    if ($feature.State -ne "Enabled") {
+        Enable-WindowsOptionalFeature -Online -FeatureName $FeatureName
+    }
+}
 
-# NetFx dependencies
+# Install dependencies
 dism /online /Enable-Feature /FeatureName:NetFx4 /All
 
-# ASP dependencies
-dism /online /enable-feature /all /featurename:IIS-ASPNET45
+# Enable IIS features
+$iisFeatures = @(
+    "IIS-WebServerRole", "IIS-WebServer", "IIS-CommonHttpFeatures", "IIS-Security", "IIS-RequestFiltering", "IIS-StaticContent",
+    "IIS-DefaultDocument", "IIS-DirectoryBrowsing", "IIS-HttpErrors", "IIS-ApplicationDevelopment", "IIS-WebSockets", "IIS-ApplicationInit",
+    "IIS-NetFxExtensibility45", "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ASP", "IIS-ASPNET45", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
+    "IIS-HttpLogging", "IIS-Performance", "IIS-HttpCompressionStatic", "IIS-WebServerManagementTools", "IIS-ManagementConsole", "IIS-ManagementService"
+)
 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerRole
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-CommonHttpFeatures
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-Security 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-RequestFiltering 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-StaticContent
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-DefaultDocument
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-DirectoryBrowsing
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpErrors 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ApplicationDevelopment
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebSockets 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ApplicationInit
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-NetFxExtensibility45
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIExtensions
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIFilter
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ASP
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ASPNET45
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ServerSideIncludes
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HealthAndDiagnostics
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpLogging 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-Performance
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpCompressionStatic
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerManagementTools
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ManagementConsole 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ManagementService
+foreach ($feature in $iisFeatures) {
+    Enable-WindowsFeatureIfNotEnabled -FeatureName $feature
+}
+
+# Install ASP dependencies
+Enable-WindowsFeatureIfNotEnabled -FeatureName "IIS-ASPNET45"
 
 # Install Chocolatey
-Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install WebDeploy (It will deploy 3.6)
+# Install WebDeploy
 choco install webdeploy -y
 
-# DotNet Net Bundle 6.0.14
-Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe" -OutFile "dotnet-hosting-6.0.14-win.exe"; Start-Process "dotnet-hosting-6.0.14-win.exe" "/install /quiet" -Wait
+# Install .NET Hosting Bundle
+$dotNetHostingUrl = "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe"
+$dotNetHostingFile = "dotnet-hosting-6.0.14-win.exe"
+Invoke-WebRequest -Uri $dotNetHostingUrl -OutFile $dotNetHostingFile
+Start-Process $dotNetHostingFile "/install /quiet" -Wait
+
+# Restart IIS
 Restart-Service -Name W3SVC

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/.gitignore
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/.gitignore
@@ -1,1 +1,2 @@
 bootstrap_win.txt
+thumbprint.txt

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/00-main.json.pkr.hcl
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/00-main.json.pkr.hcl
@@ -12,6 +12,22 @@ variable "region" {
   default = "eu-central-1"
 }
 
+variable "instance_type" {
+  type    = string
+  default = "t3.xlarge"
+}
+
+variable "winrm_username" {
+  type    = string
+  default = "Administrator"
+}
+
+variable "winrm_password" {
+  type      = string
+  default   = null
+  sensitive = true
+}
+
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }
@@ -19,8 +35,8 @@ locals {
 source "amazon-ebs" "firstrun-windows" {
   ami_name      = "packer-windows-demo-${local.timestamp} PROD"
   communicator  = "winrm"
-  instance_type = "t3.xlarge"
-  region        = "${var.region}"
+  instance_type = var.instance_type
+  region        = var.region
   source_ami_filter {
     filters = {
       name                = "Windows_Server-2022-English-Full-Base*"
@@ -31,8 +47,8 @@ source "amazon-ebs" "firstrun-windows" {
     owners      = ["amazon"]
   }
   user_data_file = "./bootstrap_win.txt"
-  winrm_password = "SuperS3cr3t!!!!"
-  winrm_username = "Administrator"
+  winrm_password = var.winrm_password
+  winrm_username = var.winrm_username
 }
 
 build {
@@ -42,9 +58,12 @@ build {
   provisioner "powershell" {
     script = "./ISS.ps1"
   }
-  // provisioner "powershell" {
-  //   script = "./Octopus.ps1"
-  // }
+  provisioner "powershell" {
+    script = "./Octopus.ps1"
+  }
+  provisioner "powershell" {
+    script = "./Hardening.ps1"
+  }
 
   provisioner "windows-restart" {}
 }

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/Hardening.ps1
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/Hardening.ps1
@@ -1,0 +1,29 @@
+# Sample Hardening.ps1
+#
+# This script demonstrates a basic example of applying some CIS benchmarks for Windows Server 2022.
+# It is not exhaustive and should not be considered a complete solution for Windows hardening.
+
+# Disable SMBv1
+Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" SMB1 -Type DWORD -Value 0
+
+# Set Minimum Password Length to 14 characters
+Set-LocalUser -MinimumPasswordLength 14
+
+# Set Account Lockout Threshold to 5 invalid attempts
+net accounts /lockoutthreshold:5
+
+# Set Account Lockout Duration to 15 minutes
+net accounts /lockoutduration:15
+
+# Set Reset Account Lockout Counter After to 15 minutes
+net accounts /lockoutwindow:15
+
+# Configure Audit Policy to include Success and Failure for 'Account Logon Events' and 'Logon Events'
+auditpol /set /subcategory:"Account Logon" /success:enable /failure:enable
+auditpol /set /subcategory:"Logon" /success:enable /failure:enable
+
+# Enable Windows Firewall
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+
+# Block incoming traffic on unused ports (example: block incoming traffic on port 445)
+New-NetFirewallRule -DisplayName "Block Unused Port 445" -Direction Inbound -Protocol TCP -LocalPort 445 -Action Block

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
@@ -17,7 +17,7 @@ dism /online /Enable-Feature /FeatureName:NetFx4 /All
 $iisFeatures = @(
     "IIS-WebServerRole", "IIS-WebServer", "IIS-CommonHttpFeatures", "IIS-Security", "IIS-RequestFiltering", "IIS-StaticContent",
     "IIS-DefaultDocument", "IIS-DirectoryBrowsing", "IIS-HttpErrors", "IIS-ApplicationDevelopment", "IIS-WebSockets", "IIS-ApplicationInit",
-    "IIS-NetFxExtensibility45", "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ASP", "IIS-ASPNET45", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
+    "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
     "IIS-HttpLogging", "IIS-Performance", "IIS-HttpCompressionStatic", "IIS-WebServerManagementTools", "IIS-ManagementConsole", "IIS-ManagementService"
 )
 

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
@@ -32,8 +32,8 @@ Enable-WindowsFeatureIfNotEnabled -FeatureName "IIS-ASPNET45"
 Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install WebDeploy
-choco install webdeploy -y
+# # Install WebDeploy # Part of demo pre octopus
+# choco install webdeploy -y
 
 # Install .NET Hosting Bundle
 $dotNetHostingUrl = "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe"

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/ISS.ps1
@@ -1,48 +1,45 @@
+# Function to enable features with error checking
+function Enable-WindowsFeatureIfNotEnabled {
+    param (
+        [string]$FeatureName
+    )
 
-# Install IIS and its dependencies
-# To list all Windows Features: dism /online /Get-Features
-# Get-WindowsOptionalFeature -Online 
-# LIST All IIS FEATURES: 
-# Get-WindowsOptionalFeature -Online | where FeatureName -like 'IIS-*'
+    $feature = Get-WindowsOptionalFeature -Online -FeatureName $FeatureName
+    if ($feature.State -ne "Enabled") {
+        Enable-WindowsOptionalFeature -Online -FeatureName $FeatureName
+    }
+}
 
-# NetFx dependencies
+# Install dependencies
 dism /online /Enable-Feature /FeatureName:NetFx4 /All
 
-# ASP dependencies
-dism /online /enable-feature /all /featurename:IIS-ASPNET45
+# Enable IIS features
+$iisFeatures = @(
+    "IIS-WebServerRole", "IIS-WebServer", "IIS-CommonHttpFeatures", "IIS-Security", "IIS-RequestFiltering", "IIS-StaticContent",
+    "IIS-DefaultDocument", "IIS-DirectoryBrowsing", "IIS-HttpErrors", "IIS-ApplicationDevelopment", "IIS-WebSockets", "IIS-ApplicationInit",
+    "IIS-NetFxExtensibility45", "IIS-ISAPIExtensions", "IIS-ISAPIFilter", "IIS-ASP", "IIS-ASPNET45", "IIS-ServerSideIncludes", "IIS-HealthAndDiagnostics",
+    "IIS-HttpLogging", "IIS-Performance", "IIS-HttpCompressionStatic", "IIS-WebServerManagementTools", "IIS-ManagementConsole", "IIS-ManagementService"
+)
 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerRole
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-CommonHttpFeatures
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-Security 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-RequestFiltering 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-StaticContent
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-DefaultDocument
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-DirectoryBrowsing
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpErrors 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ApplicationDevelopment
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebSockets 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ApplicationInit
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-NetFxExtensibility45
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIExtensions
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIFilter
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ASP
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ASPNET45
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ServerSideIncludes
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HealthAndDiagnostics
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpLogging 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-Performance
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpCompressionStatic
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerManagementTools
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ManagementConsole 
-Enable-WindowsOptionalFeature -Online -FeatureName IIS-ManagementService
+foreach ($feature in $iisFeatures) {
+    Enable-WindowsFeatureIfNotEnabled -FeatureName $feature
+}
+
+# Install ASP dependencies
+Enable-WindowsFeatureIfNotEnabled -FeatureName "IIS-ASPNET45"
 
 # Install Chocolatey
-Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install WebDeploy (It will deploy 3.6)
+# Install WebDeploy
 choco install webdeploy -y
 
-# DotNet Net Bundle 6.0.14
-Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe" -OutFile "dotnet-hosting-6.0.14-win.exe"; Start-Process "dotnet-hosting-6.0.14-win.exe" "/install /quiet" -Wait
+# Install .NET Hosting Bundle
+$dotNetHostingUrl = "https://download.visualstudio.microsoft.com/download/pr/321a2352-a7aa-492a-bd0d-491a963de7cc/6d17be7b07b8bc22db898db0ff37a5cc/dotnet-hosting-6.0.14-win.exe"
+$dotNetHostingFile = "dotnet-hosting-6.0.14-win.exe"
+Invoke-WebRequest -Uri $dotNetHostingUrl -OutFile $dotNetHostingFile
+Start-Process $dotNetHostingFile "/install /quiet" -Wait
+
+# Restart IIS
 Restart-Service -Name W3SVC

--- a/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/Octopus.ps1
+++ b/00-Packer/AWS/AMI/PROD/PROD-WEB-X-AMI/Octopus.ps1
@@ -5,11 +5,20 @@ Invoke-WebRequest $octopusUrl -OutFile $octopusInstaller
 Start-Process msiexec.exe -ArgumentList "/i $octopusInstaller /quiet" -Wait
 
 # Install Octopus Deploy Tentacle
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" create-instance --instance "Tentacle" --config "C:\Octopus\Tentacle.config"
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" new-certificate --instance "Tentacle" --if-blank
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" configure --instance "Tentacle" --reset-trust
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" configure --instance "Tentacle" --app "C:\Octopus\Applications" --port "10933" --noListen "False"
-##Leaked trust and rotated##
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" configure --instance "Tentacle" --trust "5CA0B7EDF9EF2FE8A8DE95C8B95DAD4B3DA19C88"
-"netsh" advfirewall firewall add rule "name=Octopus Deploy Tentacle" dir=in action=allow protocol=TCP localport=10933
-"C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" service --instance "Tentacle" --install --stop --start
+$tentaclePath = "C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe"
+$instanceName = "Tentacle"
+$configPath = "C:\Octopus\Tentacle.config"
+$appPath = "C:\Octopus\Applications"
+$port = "10933"
+
+& $tentaclePath create-instance --instance $instanceName --config $configPath
+& $tentaclePath new-certificate --instance $instanceName --if-blank
+& $tentaclePath configure --instance $instanceName --reset-trust
+& $tentaclePath configure --instance $instanceName --app $appPath --port $port --noListen "False"
+
+# Store the trusted thumbprint in an environment variable or a secrets manager
+$thumbprint = Get-Content 'C:\path\to\thumbprint.txt'
+
+& $tentaclePath configure --instance $instanceName --trust $thumbprint
+netsh advfirewall firewall add rule "name=Octopus Deploy Tentacle" dir=in action=allow protocol=TCP localport=$port
+& $tentaclePath service --instance $instanceName --install --stop --start

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-## Motivation:
+# Infrastructure Suite Demo with Built-In Instrumentation
 
-- A demonstration of a in-the-middle infrastructure suite, with instrumentation built around operational convenience & reproducibility 🚀
+This repository demonstrates an infrastructure suite with a focus on operational convenience and reproducibility.
 
-## Given more time:
+## Motivation
+
+- A demonstration of an in-the-middle infrastructure suite, with instrumentation built around operational convenience & reproducibility 🚀
+
+## Given more time
 
 - Register nodes into target groups & ASG(s) 📝
 - Register load balancer(s) to point to target group(s) 📝
@@ -12,7 +16,7 @@
 
 ![Diagram](docs/images/diagram.png)
 
-## Demo:
+## Demo
 
 DEV:
 
@@ -23,11 +27,11 @@ PROD: (close your eyes and imagine a load-balancer)
 - http://18.198.105.88/api/weather
 - http://3.76.20.32/api/weather
 
-## 📜 SRC Description:
+## 📜 SRC Description
 
 - A random-off-the shelf stateless app ( because stateless means happy Ops ) app, that simulates a weather API at `/api/weather` ☁️
 
-## 🚀 Features:
+## 🚀 Features
 
 - 🚀 Uses Packer to create "Golden AMI(s)"
 - 📦 Uses Terraform to provision
@@ -37,18 +41,19 @@ PROD: (close your eyes and imagine a load-balancer)
 - 🎁 Uses Github Submodules to wrap infra around project
 - 📜 Uses Make for basic scripting convenience
 
-## 🧪 BETA Features:
+## 🧪 BETA Features
 
 - [ ] Uses Github Actions to push a "trigger" for fully automated releases
 - [ ] Add S3 Bucket for Octopus Deploy to store artifacts
 - [ ] Add S3 Bucket for Terraform to store state & lock via DynamoDB
-- [ ] Experiment with ASG(s) & Target Groups, as tennants to Octopus Deploy
+- [ ] Experiment with ASG(s) & Target Groups, as tenants to Octopus Deploy
 
-## 🛠️ TODO:
+## 🛠️ TODO
 
 - [x] Implement SEMVER
 - [x] Implement Github Actions for basic CI
 - [ ] Implement CIS Benchmark and Hardening for security.
+
 ## Where you'll need context:
 
 - [ ] AWS Account


### PR DESCRIPTION
# Windows Server 2022 Hardening with CIS Benchmarks

This repository provides a sample PowerShell script to demonstrate some basic hardening steps for Windows Server 2022, following the Center for Internet Security (CIS) benchmarks. Please note that the provided script only covers a small portion of the CIS benchmarks and should not be considered a comprehensive solution for Windows hardening. For a complete guide to securing your Windows systems, refer to the [CIS Windows Benchmarks](https://www.cisecurity.org/cis-benchmarks/).

## Contents

1. `Hardening.ps1` - A sample PowerShell script to apply selected CIS benchmarks for Windows Server 2022.

## Hardening Steps

The following hardening steps are included in the `Hardening.ps1` script:

- Disable SMBv1
- Set minimum password length to 14 characters
- Set account lockout threshold to 5 invalid attempts
- Set account lockout duration to 15 minutes
- Set reset account lockout counter after to 15 minutes
- Configure audit policy to include success and failure for 'Account Logon Events' and 'Logon Events'
- Enable Windows Firewall
- Block incoming traffic on unused ports (example: block incoming traffic on port 445)

Please note that the script does not disable Remote Desktop (RDP).

## Usage

To apply the hardening steps, run the `Hardening.ps1` script with administrative privileges:

```powershell
.\Hardening.ps1
``` 